### PR TITLE
Removing this test will allow to use marklib in iframe.contentDocument.

### DIFF
--- a/src/main/Rendering.js
+++ b/src/main/Rendering.js
@@ -42,9 +42,6 @@ class Rendering {
 
     constructor(document, cssClass, context) {
 
-        if (!(document instanceof Document)) {
-            throw 'Marklib {0} is required to be a document instance';
-        }
         /**
          * @type {Document}
          */


### PR DESCRIPTION
I got a use case in which I want to use Marklib in the document instance of an iframe. When doing this ```document instanceof Document``` will fail. Right now I have no better idea then removing the check. Whats your opinion on this?